### PR TITLE
Added two more core_ns_start functions

### DIFF
--- a/components/hoja_lib/cores/core_switch_backend.c
+++ b/components/hoja_lib/cores/core_switch_backend.c
@@ -204,6 +204,20 @@ void ns_bt_hidd_cb(esp_hidd_cb_event_t event, esp_hidd_cb_param_t *param)
 
 hoja_err_t core_ns_start(void)
 {
+    return core_ns_start_with_default_type(NS_CONTROLLER_TYPE_SNESCLASSIC);
+}
+
+hoja_err_t core_ns_start_with_default_type(uint8_t default_controller_type)
+{
+    if (loaded_settings.ns_controller_type == NS_CONTROLLER_TYPE_UNKNOWN)
+    {
+        loaded_settings.ns_controller_type = default_controller_type;
+    }
+    return core_ns_start_with_controller_type(loaded_settings.ns_controller_type);
+}
+
+hoja_err_t core_ns_start_with_controller_type(uint8_t controller_type)
+{
     const char* TAG = "core_ns_start";
     esp_err_t ret;
 
@@ -211,7 +225,7 @@ hoja_err_t core_ns_start(void)
     ns_controller_data.battery_level_full = 0x04;
     ns_controller_data.connection_info = 0x00;
 
-    loaded_settings.ns_controller_type = NS_CONTROLLER_TYPE_SNESCLASSIC;
+    loaded_settings.ns_controller_type = controller_type;
 
     // SET UP CONTROLLER TYPE VARS
     switch(loaded_settings.ns_controller_type)

--- a/components/hoja_lib/hoja_settings.c
+++ b/components/hoja_lib/hoja_settings.c
@@ -105,7 +105,7 @@ hoja_err_t hoja_settings_default(void)
     memset(loaded_settings.ns_host_bt_address, 0, 6);
     hoja_settings_generate_btmac(loaded_settings.ns_client_bt_address);
     loaded_settings.ns_controller_paired = false;
-    loaded_settings.ns_controller_type = NS_CONTROLLER_TYPE_PROCON;
+    loaded_settings.ns_controller_type = NS_CONTROLLER_TYPE_UNKNOWN;
 
     // Dinput Core stuff
     memset(loaded_settings.dinput_host_bt_address, 0, 6);

--- a/components/hoja_lib/include/cores/core_switch_backend.h
+++ b/components/hoja_lib/include/cores/core_switch_backend.h
@@ -35,6 +35,7 @@
 //#include "rbc_switch_vibration.h"
 
 /* Define controller types supported */
+#define NS_CONTROLLER_TYPE_UNKNOWN     0x00
 #define NS_CONTROLLER_TYPE_JOYCON_L    0x01
 #define NS_CONTROLLER_TYPE_JOYCON_R    0x02
 #define NS_CONTROLLER_TYPE_PROCON      0x03
@@ -71,6 +72,12 @@ extern uint8_t ns_currentReportMode;
 
 // Start the Nintendo Switch controller core
 hoja_err_t core_ns_start(void);
+
+// Start the Nintendo Switch controller core with a default controller type
+hoja_err_t core_ns_start_with_default_type(uint8_t default_controller_type);
+
+// Start the Nintendo Switch controller core with a specific controller type
+hoja_err_t core_ns_start_with_controller_type(uint8_t default_controller_type);
 
 // Stop the Nintendo Switch controller core
 hoja_err_t core_ns_stop(void);


### PR DESCRIPTION
- `core_ns_start_with_default_type` for starting the core with a default type in case the User didn't selected/saved a type.
- `core_ns_start_with_controller_type` for starting the core with a specific type, overriding the user's preferences.
- Now `core_ns_start` will call `core_ns_start_with_default_type` with `NS_CONTROLLER_TYPE_SNESCLASSIC`.

This will allow to use the library as a git submodule without needing to fork or to use any workaround like git patches.

**Breaking changes:**

`core_ns_start` is still present so there will be no compilation error, but it may generate an error on new and current installments, as it'll use the saved controller type which may differ from the physical/original/intended one. I'd suggest to mark it as deprecated and to incite to use either `core_ns_start_with_default_type` (for customizable hardware) or `core_ns_start_with_controller_type`.