### PR TITLE
Fixed Special Buttons on N64 Sub-core for Switch Core

### DIFF
--- a/cores/switch/core_switch_input.c
+++ b/cores/switch/core_switch_input.c
@@ -37,15 +37,16 @@ void ns_input_translate_full(ns_input_long_s *ns_input_long)
         ns_input_long->b_b       = hoja_button_data.button_down;
         ns_input_long->b_x       = hoja_button_data.button_up;
         ns_input_long->b_y       = hoja_button_data.button_left;
-        ns_input_long->b_plus    = hoja_button_data.button_start;
         ns_input_long->b_minus   = hoja_button_data.button_select;
-        ns_input_long->b_home    = hoja_button_data.button_home;
-        ns_input_long->b_capture = hoja_button_data.button_capture;
         ns_input_long->t_l       = hoja_button_data.trigger_l;
         ns_input_long->t_zl      = hoja_button_data.trigger_zl;
         ns_input_long->t_r       = hoja_button_data.trigger_r;
         ns_input_long->t_zr      = hoja_button_data.trigger_zr;
     }
+    
+    ns_input_long->b_plus    = hoja_button_data.button_start;
+    ns_input_long->b_home    = hoja_button_data.button_home;
+    ns_input_long->b_capture = hoja_button_data.button_capture;
 }
 
 void ns_input_translate_short(ns_input_short_s *ns_input_short)


### PR DESCRIPTION
`ns_input_long->b_plus`, `b_home` and `b_capture` were *accidentally* excluded from the output when `_ns_subcore` is `NS_TYPE_N64`.

While the original N64 controller didn't have Home and Capture buttons, they should be still available as the new N64 Control for the Switch Online does actually have those, and they works fine on the Nintendo Switch even if `_ns_subcore` is on `NS_TYPE_N64` (after this commit)